### PR TITLE
fix: reference json files as lists and don't exclude states with zero

### DIFF
--- a/src/lds_datasets/db/duckdb.py
+++ b/src/lds_datasets/db/duckdb.py
@@ -42,17 +42,17 @@ wards_removed_per_state = duckdb.sql("SELECT address.state, COUNT(*) as count FR
 
 # combined stakes added, removed, and net change per state in the USA
 net_change_usa_stakes = duckdb.sql("""
-SELECT a.state,
-            a.added,
-            r.removed,
-            a.added - r.removed AS net_change
+SELECT COALESCE(a.state, r.state) AS state,
+            COALESCE(a.added, 0) AS added,
+            COALESCE(r.removed, 0) AS removed,
+            COALESCE(a.added, 0) - COALESCE(r.removed, 0) AS net_change
 FROM
     (SELECT address.state,
             COUNT(*) AS added
      FROM stakes_added
      WHERE address.countryCode3 = 'USA'
      GROUP BY address.state) a
-JOIN
+FULL OUTER JOIN
     (SELECT address.state,
             COUNT(*) AS removed
      FROM stakes_removed
@@ -61,19 +61,20 @@ JOIN
 ORDER BY net_change ASC;
 """)
 
+
 # combined wards added, removed, and net change per state in the USA
 net_change_usa_wards = duckdb.sql("""
-SELECT a.state,
-         a.added,
-         r.removed,
-         a.added - r.removed AS net_change
+SELECT COALESCE(a.state, r.state) AS state,
+         COALESCE(a.added, 0) AS added,
+         COALESCE(r.removed, 0) AS removed,
+         COALESCE(a.added, 0) - COALESCE(r.removed, 0) AS net_change
 FROM
     (SELECT address.state,
             COUNT(*) AS added
      FROM wards_added
      WHERE address.countryCode3 = 'USA'
      GROUP BY address.state) a
-JOIN
+FULL OUTER JOIN
     (SELECT address.state,
             COUNT(*) AS removed
      FROM wards_removed
@@ -93,7 +94,7 @@ FROM
      FROM branches_added
      WHERE address.countryCode3 = 'USA'
      GROUP BY address.state) a
-JOIN
+OUTER JOIN
     (SELECT address.state,
             COUNT(*) AS removed
      FROM branches_removed

--- a/src/lds_datasets/units/units.py
+++ b/src/lds_datasets/units/units.py
@@ -851,7 +851,7 @@ def get_stakes_json() -> set[Unit]:
     stakes: set[Unit] = set()
     with open(TODAY_STAKES_JSON, "r") as f:
         stakes_json = json.load(f)
-    for stake_json in stakes_json["stakes"]:
+    for stake_json in stakes_json:
         stake = Unit.model_validate(stake_json)
         stakes.add(stake)
     return stakes
@@ -863,7 +863,7 @@ def get_yesterday_stakes_json() -> set[Unit]:
     try:
         with open(YESTERDAY_STAKES_JSON, "r") as f:
             stakes_json = json.load(f)
-        for stake_json in stakes_json["stakes"]:
+        for stake_json in stakes_json:
             stake = Unit.model_validate(stake_json)
             stakes.add(stake)
     except FileNotFoundError:
@@ -881,7 +881,7 @@ def get_yesterday_stakes_json() -> set[Unit]:
                         prior_day=prior_day,
                     )
                     stakes_json = json.load(f)
-                for stake_json in stakes_json["stakes"]:
+                for stake_json in stakes_json:
                     stake = Unit.model_validate(stake_json)
                     stakes.add(stake)
                 break
@@ -905,7 +905,7 @@ def get_wards_json() -> set[Unit]:
     wards: set[Unit] = set()
     with open(TODAY_WARDS_JSON, "r") as f:
         wards_json = json.load(f)
-    for ward_json in wards_json["wards"]:
+    for ward_json in wards_json:
         ward = Unit.model_validate(ward_json)
         wards.add(ward)
     return wards
@@ -917,7 +917,7 @@ def get_yesterday_wards_json() -> set[Unit]:
     try:
         with open(YESTERDAY_WARDS_JSON, "r") as f:
             wards_json = json.load(f)
-        for ward_json in wards_json["wards"]:
+        for ward_json in wards_json:
             ward = Unit.model_validate(ward_json)
             wards.add(ward)
     except FileNotFoundError:
@@ -934,7 +934,7 @@ def get_yesterday_wards_json() -> set[Unit]:
                         "Found a wards json file from a prior day.", prior_day=prior_day
                     )
                     wards_json = json.load(f)
-                for ward_json in wards_json["wards"]:
+                for ward_json in wards_json:
                     ward = Unit.model_validate(ward_json)
                     wards.add(ward)
                 break


### PR DESCRIPTION
This commit fixes two bugs:
1. the structure of the json files has changed, we reference a list of objects rather than an object "wards" or "stakes" containing a list.
2. the original duckdb net queries excluded states unless they contained both added and removed. That is remedied now.